### PR TITLE
Add support for arbitrary template importing & hiding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- Add: Support for `include`-ing one template from within another. Any file from the cargo root can be imported. (https://github.com/schneems/drydoc/pull/2)
+- Add: A custom filter `dochide` this can be used within a jinja template to prepend every line with a rustdoc hide directive `# `. This can be used in combination with the ability to `include` another template to compose files. (https://github.com/schneems/drydoc/pull/2)
+
 ## 0.1.0
 
 - First

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,11 +66,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
 name = "minijinja"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212b4cab3aad057bc6e611814472905546c533295723b9e26a31c7feb19a8e65"
 dependencies = [
+ "memo-map",
+ "self_cell",
  "serde",
 ]
 
@@ -101,6 +109,12 @@ checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d369a96f978623eb3dc28807c4852d6cc617fed53da5d3c400feff1ef34a714a"
 
 [[package]]
 name = "serde"

--- a/drydoc/Cargo.toml
+++ b/drydoc/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 
 [dependencies]
 fs-err = "3.0.0"
-minijinja = {version = "2.6.0", optional = true }
+minijinja = {version = "2.6.0", optional = true, features = ["loader"] }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }

--- a/drydoc/README.md
+++ b/drydoc/README.md
@@ -80,7 +80,21 @@ You can use control and flow operators like [for](https://jinja.palletsprojects.
 
 ## Advanced JINJA: Extends, Include and Import
 
-JINJA templates can render other JINJA templates through directives such as `include`. This feature is not supported **yet** but I've got an idea of how to do it. This feature would let you meta-compose your docs.
+You can include a jinja template from another by using a full path from the crate root and the `include` jinja keyword:
+
+```jinja
+{% include "docs/header.rs" %}
+```
+
+If you want to include a template but hide it from the end user, you can use the `dochide` filter that is provided by drydoc:
+
+```jinja
+{% filter dochide %}
+{% include "docs/header.rs" %}
+{% endfilter %}
+```
+
+Every file in the crate is available as a template to import by default. For more info on `includes` and related functionality, see [template inheritance](https://jinja.palletsprojects.com/en/stable/templates/#template-inheritance).
 
 ## Rust-analyzer support
 

--- a/drydoc_usage/docs/import_example.rs
+++ b/drydoc_usage/docs/import_example.rs
@@ -1,1 +1,3 @@
-{% include 'header.rs' %}
+{% filter dochide %}
+{% include "docs/header.rs" %}
+{% endfilter %}

--- a/drydoc_usage/src/lib.rs
+++ b/drydoc_usage/src/lib.rs
@@ -11,9 +11,7 @@
 #![doc = drydoc!(path = "docs/person.rs", toml = { name = "Schneems" })]
 //! ```
 //!
-// ```
-// TODO
-// #![doc = drydoc!(path = "docs/import_example.rs")]
-// ```
-
+//! ```
+#![doc = drydoc!(path = "docs/import_example.rs")]
+//! ```
 pub use drydoc::drydoc;


### PR DESCRIPTION
- Add: Support for `include`-ing one template from within another. Any file from the cargo root can be imported.
- Add: A custom filter `dochide` this can be used within a jinja template to prepend every line with a rustdoc hide directive `# `. This can be used in combination with the ability to `include` another template to compose files.


## Docs

You can include a jinja template from another by using a full path from the crate root and the `include` jinja keyword:

```jinja
{% include "docs/header.rs" %}
```

If you want to include a template but hide it from the end user, you can use the `dochide` filter that is provided by drydoc:

```jinja
{% filter dochide %}
{% include "docs/header.rs" %}
{% endfilter %}
```

Every file in the crate is available as a template to import by default. For more info on `includes` and related functionality, see [template inheritance](https://jinja.palletsprojects.com/en/stable/templates/#template-inheritance).